### PR TITLE
Implement derussification

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,10 +1,19 @@
-# FAANG Interview. Бортовые заметки сообщества
+# FAANG Interview. Бортові нотатки спільноти
 
-## Введение
-Этот [репозиторий](https://github.com/faang-interview/faang-interview.github.io) создан для “FAANG Interview” сообщества с целью упорядочить полезные ресурсы упоминаемые в чате. Каждая ссылка  в документе должна сопровождаться описанием. Не стесняемся слать pull реквесты и делать репозиторий лучше с каждым днем.
+> By participating in the community, you agree to the next statements: 
+> - I agree that russia is a terrorist state and did genocide against Ukraine
+> - I agree that russia must pay reparations to Ukraine in a full scale
+> - I agree that Crimean peninsula is the territory of Ukraine
+> - I agree that putin is a criminal and must appear in International Court of Justice
 
-## Аббревиатуры
-- FAANG - Facebook, Apple, Amazon, Netflix, Google. Usually also means Microsoft, Github, Linkedin, Instagram, Snapchat, Palantir, Bloomberg, IBM.
+
+## Вступ
+Цей [репозиторій](https://github.com/faang-interview/faang-interview.github.io) створено для "FAANG Interview" спільноти з метою впорядкувати корисні ресурси, що згадуються в чаті.
+Кожне посилання в документі має супроводжуватися описом.
+Не соромтеся надсилати pull requests і робити репозиторій кращим з кожним днем.
+
+## Абревіатури
+- FAANG - Facebook, Apple, Amazon, Netflix, Google. Usually also means Microsoft, GitHub, Linkedin, Instagram, Snapchat, Palantir, Bloomberg, IBM.
 - LP - [Leadership Principles](https://www.aboutamazon.com/working-at-amazon/our-leadership-principles) (by Amazon)
 - CtCI - Cracking the Coding Interview (book)
 - SRE - Site Reliability Engineer
@@ -28,186 +37,180 @@
 - TC - Total compensation
 - CLRS - Introduction of Algorithms ([book](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844))
 
-## Mock  интервью сообщества
-Мы проводим технические мок-интервью в парах каждую неделю, больше деталей о том как это проходит в [этом документе](https://docs.google.com/document/d/1n-7-U6y2Cr58AygViDWkiqtKRq_jQdsRNKOfc-Uw1xE/edit?usp=sharing) (док открыт для комментирования).
-[Гайд как проводить мок-интервью](https://docs.google.com/document/d/1cX5zhd5Yb3IlMA2smbs8XgQCIapgeQQ1LW-01DJ8W5M/edit#heading=h.54uirbe8rdgs).
+## Mock-інтерв'ю спільноти
+Ми проводимо технічні мок-інтерв'ю в парах щотижня, більше деталей про те, як це проходить, у [цьому документі](https://docs.google.com/document/d/1n-7-U6y2Cr58AygViDWkiqtKRq_jQdsRNKOfc-Uw1xE/edit?usp=sharing) (док відкритий для коментування).
+[Гайд як проводити мок-інтерв'ю](https://docs.google.com/document/d/1cX5zhd5Yb3IlMA2smbs8XgQCIapgeQQ1LW-01DJ8W5M/edit#heading=h.54uirbe8rdgs).
 
-## Разные полезные ссылки
-- Сайты где можно решать задачи:
+## Різні корисні посилання
+- Сайти, де можна вирішувати завдання:
   - [https://leetcode.com/](https://leetcode.com/)
   - [https://www.interviewbit.com/](https://www.interviewbit.com/)
- - [Как попасть в Google: инструкция по подготовке](https://dou.ua/lenta/articles/google-interview/) - статья Сергея Семы о подготовке к интервью в фаанг.
- - [http://larrr.com/](http://larrr.com/) - блог Ларисы о Гугл, интервью, жизни в долине. 
-  - [Хочу работать в Google: Read Me First!](http://larrr.com/wp-content/uploads/2016/10/InterviewPreparationGuide.pdf) - подборка материалов по подготовке
-  - [https://t.me/empireinthemaking](https://t.me/empireinthemaking) - телеграмм канал Ларисы
-- [Cracking the coding interview book](https://www.amazon.com/Cracking-Coding-Interview-Programming-Questions/dp/0984782850)  - книга, ставшая классикой при подготовке
-- Mock  интервью
-  - [https://www.pramp.com/](https://www.pramp.com/#/) -  парные мок интервью
-  - [http://www.gainlo.co/](http://www.gainlo.co/)  платный. позволяет собеседоваться с реальными сотрудниками из ФААНГ. сайт гарантирует это. цена указывается своя на каждого интервьюера, от 100 до 200 долларов за мок. обещают подробный фидбэк после мока. Another opinion about the service.
+ - [Як потрапити в Google: інструкція з підготовки](https://dou.ua/lenta/articles/google-interview/) - стаття Сергія Семи про підготовку до інтерв'ю у фаанг.
+- [Cracking the coding interview book](https://www.amazon.com/Cracking-Coding-Interview-Programming-Questions/dp/0984782850) - книга, що стала класикою при підготовці
+- [http://larrr.com/ (рос.)](http://larrr.com/) - блог Лариси про Гугл, інтерв'ю, життя в долині.
+- [Хочу працювати в Google: Read Me First! (рос.)](http://larrr.com/wp-content/uploads/2016/10/InterviewPreparationGuide.pdf) - добірка матеріалів з підготовки
+- [https://t.me/empireinthemaking (рос.)](https://t.me/empireinthemaking) - телеграм-канал Лариси
+- Мок-інтерв'ю
+  - [https://www.pramp.com/](https://www.pramp.com/#/) - парні мок інтерв'ю
+  - [http://www.gainlo.co/](http://www.gainlo.co/)  платний. Дає змогу співбесідуватися з реальними співробітниками з FAANG. Сайт гарантує це. Ціна вказується своя на кожного інтерв'юера, від 100 до 200 доларів за мок. Обіцяють детальний фідбек після мока. Another opinion about the service.
   - [https://interviewing.io/](https://interviewing.io/) - Practice interviewing with engineers from Google, Facebook, and more... anonymously. Price varies $100-200.
-- Гайды по подготовке к интервью:
-  - [Interview preparation Guide](https://paper.dropbox.com/doc/Interview-Preparation-Guide-PHeQLxMXugqC1vz72wgtX) - подборка ссылок на полезные репозитории, видео, курсы, и книги.
+- Гайди з підготовки до інтерв'ю:
+  - [Interview preparation Guide](https://paper.dropbox.com/doc/Interview-Preparation-Guide-PHeQLxMXugqC1vz72wgtX) - добірка посилань на корисні репозиторії, відео, курси та книги.
   - [Ilyushin/google-interview-university](https://github.com/Ilyushin/google-interview-university): A complete daily plan for studying to become a Google software engineer. 
   - [Tech Interview Handbook](https://yangshun.github.io/tech-interview-handbook/)
   - [Coding Interviews: Questions, Analysis & Solutions (Expert's Voice in Programming)](https://www.amazon.com/Coding-Interviews-Questions-Solutions-Programming-ebook/dp/B00ACC6AQY)
-  - [Uber Software Developer Interview Prep](https://s3.amazonaws.com/ubercandidateprep/index.html) - подготовка к интервью в Uber
+  - [Uber Software Developer Interview Prep](https://s3.amazonaws.com/ubercandidateprep/index.html) - підготовка до інтерв'ю в Uber
   - [The Interview Study Guide For Software Engineers](https://dev.to/seattledataguy/the-interview-study-guide-for-software-engineers-764) - DEV Community 
   - [Comprehensive Data Structure](https://leetcode.com/discuss/general-discussion/494279/Comprehensive-Data-Structure-and-Algorithm-Study-Guide) and Algorithm Study Guide 
-- [LinkedIn группа участников чата для обмена контактами](https://www.linkedin.com/groups/8951002/)
-- [Статья про интервью в Амазон от одного из менеджеров](https://medium.com/@allo/%D0%BE-%D1%81%D0%BE%D0%B1%D0%B5%D1%81%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B8-%D0%B2-%D0%B0%D0%BC%D0%B0%D0%B7%D0%BE%D0%BD-27e649323c4b)
-- [Сервис для проверки своего резюме (гуглить боты ATS)](https://www.topcv.com/)
+- [LinkedIn група учасників чату для обміну контактами](https://www.linkedin.com/groups/8951002/)
+- [Стаття про інтерв'ю в Амазон від одного з менеджерів (рос.)](https://medium.com/@allo/%D0%BE-%D1%81%D0%BE%D0%B1%D0%B5%D1%81%D0%B5%D0%B4%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B8-%D0%B2-%D0%B0%D0%BC%D0%B0%D0%B7%D0%BE%D0%BD-27e649323c4b)
+- [Сервіс для перевірки свого резюме (гуглити боти ATS)](https://www.topcv.com/)
 
-## Курсы, книги, статьи по алгоритмам и структурам данных
-- Курсы
-  - [Курсы по алгоритмам от Роберта Седжвика Часть 1](https://www.coursera.org/learn/algorithms-part1)
-  - [Курсы по алгоритмам от Роберта Седжвика Часть 2](https://www.coursera.org/learn/algorithms-part2)
-  - [https://cses.fi/book/book.pdf](https://cses.fi/book/book.pdf)  -  Вот хорошая книга для подготовки для интервью. Там и DP есть. Она в основном для тех кто готовится к олимпиадам, т.е. уровень выше, но покрывает и темы которые попадаются в интервью
-  - [Coderust: Hacking the Coding Interview](https://www.educative.io/courses/coderust-hacking-the-coding-interview?authorName=Coderust) - Платный курс (в текстовом виде) по алгоритмам и структурам данных 
+## Курси, книги, статті з алгоритмів і структур даних
+- Курси
+  - [Курси з алгоритмів від Роберта Седжвіка Частина 1](https://www.coursera.org/learn/algorithms-part1)
+  - [Курси з алгоритмів від Роберта Седжвіка Частина 2](https://www.coursera.org/learn/algorithms-part2)
+  - [https://cses.fi/book/book.pdf](https://cses.fi/book/book.pdf)  -  Ось хороша книжка для підготовки для інтерв'ю. Там і DP є. Вона здебільшого для тих, хто готується до олімпіад, тобто рівень вищий, але покриває і теми, які трапляються в інтерв'ю
+  - [Coderust: Hacking the Coding Interview](https://www.educative.io/courses/coderust-hacking-the-coding-interview?authorName=Coderust) - Платний курс (у текстовому вигляді) з алгоритмів і структур даних
   - [Master the Coding Interview: Data Structures + Algorithms](https://www.udemy.com/course/master-the-coding-interview-data-structures-algorithms/) - курс на udemy
-  - [JavaScript (JS) Algorithms and Data Structures Masterclass](https://www.udemy.com/js-algorithms-and-data-structures-masterclass/) - Курс ознакомляет с основными принципами решения задачек, основными алгоритмами и структурами данных
-  - [Coding Interview Bootcamp Algorithms, Data Structures Course](https://www.udemy.com/coding-interview-bootcamp-algorithms-and-data-structure/) На практике дает возможность решить самые популярные задачки, потом идет решение с его разбором с несколькими подходами. Показывает как на практике применять те или иные подходы и оценивать их сложности (big O) и выбирать лучшее решение.
-  - [Algorithmic Toolbox](https://www.coursera.org/learn/algorithmic-toolbox?specialization=data-structures-algorithms) Курс для тех кто в начале пути. Поможет понять big-O, элементарные алгоритмы и подходы к ним.
-  - [Computer Sc - Data Structures and Algorithms](https://www.youtube.com/playlist?list=PLBF3763AF2E1C572F) - видео курс
-  - [Algorithms, Computer science, Computing](https://www.khanacademy.org/computing/computer-science/algorithms) - курс по алгоритмам на Khan Academy
-  - [Grokking the Coding Interview: Patterns for Coding Questions платный курс “Patterns for Coding Questions”](https://www.educative.io/courses/grokking-the-coding-interview)
+  - [JavaScript (JS) Algorithms and Data Structures Masterclass](https://www.udemy.com/js-algorithms-and-data-structures-masterclass/) - Курс ознайомлює з основними принципами розв'язання задачок, основними алгоритмами та структурами даних
+  - [Coding Interview Bootcamp Algorithms, Data Structures Course](https://www.udemy.com/coding-interview-bootcamp-algorithms-and-data-structure/) На практиці дає можливість розв'язати найпопулярніші задачки, потім іде розв'язання з його розбором з кількома підходами. Показує як на практиці застосовувати ті чи йнші підходи й оцінювати їх складності (big O) та обирати найкраще рішення.
+  - [Algorithmic Toolbox](https://www.coursera.org/learn/algorithmic-toolbox?specialization=data-structures-algorithms) - Курс для тих, хто на початку шляху. Допоможе зрозуміти big-O, елементарні алгоритми та підходи до них.
+  - [Computer Sc - Data Structures and Algorithms](https://www.youtube.com/playlist?list=PLBF3763AF2E1C572F) - відео курс
+  - [Algorithms, Computer science, Computing](https://www.khanacademy.org/computing/computer-science/algorithms) - курс з алгоритмів на Khan Academy
+  - [Grokking the Coding Interview: Patterns for Coding Questions платний курс “Patterns for Coding Questions”](https://www.educative.io/courses/grokking-the-coding-interview)
   - [Data Structures and Algorithms](https://www.coursera.org/specializations/data-structures-algorithms) - coursera course
   - [Introduction to Algorithms](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/index.htm) - course from MIT
   - [Lectures in Advanced Data Structures (6.851)](https://courses.csail.mit.edu/6.851/fall17/lectures/) - MIT lectures by prof. Erik Demaine
-  - [Intro to Algorithms and Data Structures](https://www.udacity.com/course/data-structures-and-algorithms-in-python--ud513) - от Google на Python (бесплатно, в конце есть разбор всех этапов онсайт интервью)
+  - [Intro to Algorithms and Data Structures](https://www.udacity.com/course/data-structures-and-algorithms-in-python--ud513) - від Google на Python (безплатно, наприкінці є розбір усіх етапів онсайт-інтерв'ю)
 - Книги
-  - [Algorithms, 4th Edition by Robert Sedgewick and Kevin Wayne](https://algs4.cs.princeton.edu/home/) - более расширенный вариант курсов выше. [слайды к книге](https://algs4.cs.princeton.edu/lectures/https://algs4.cs.princeton.edu/lectures/)
+  - [Algorithms, 4th Edition by Robert Sedgewick and Kevin Wayne](https://algs4.cs.princeton.edu/home/) - більш розширений варіант курсів вище. [слайди до книги](https://algs4.cs.princeton.edu/lectures/https://algs4.cs.princeton.edu/lectures/)
   - [Computer Science Distilled: Learn the Art of Solving Computational Problems](https://www.amazon.com/Computer-Science-Distilled-Computational-Problems/dp/0997316020)
-  - [Грокаем Алгоритмы. Иллюстрированное пособие для программистов и любопытствующих](https://github.com/mduisenov/GrokkingAlgorithms/blob/master/%D0%91%D1%85%D0%B0%D1%80%D0%B3%D0%B0%D0%B2%D0%B0%20%D0%90.%20-%20%D0%93%D1%80%D0%BE%D0%BA%D0%B0%D0%B5%D0%BC%20%D0%90%D0%BB%D0%B3%D0%BE%D1%80%D0%B8%D1%82%D0%BC%D1%8B.%20%D0%98%D0%BB%D0%BB%D1%8E%D1%81%D1%82%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%BE%D0%B5%20%D0%BF%D0%BE%D1%81%D0%BE%D0%B1%D0%B8%D0%B5%20%D0%B4%D0%BB%D1%8F%20%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B0%D0%BC%D0%BC%D0%B8%D1%81%D1%82%D0%BE%D0%B2%20%D0%B8%20%D0%BB%D1%8E%D0%B1%D0%BE%D0%BF%D1%8B%D1%82%D1%81%D1%82%D0%B2%D1%83%D1%89%D0%B8%D1%85%20-%202017.PDF)
+  - [Grokking Algorithms. An illustrated guide for programmers and other curious people](https://www.manning.com/books/grokking-algorithms)
   - [Algorithms by Jeff Erickson](http://jeffe.cs.illinois.edu/teaching/algorithms/)
-  - [Data Structures and Algorithms in Python](https://www.wiley.com/en-ua/Data+Structures+and+Algorithms+in+Python-p-9781118549582) - книга по алгоритмам на Python
-  - [Problem Solving with Algorithms and Data Structures using Python](https://runestone.academy/runestone/books/published/pythonds/index.html) - еще одна книга  по алгоритмам на Python
+  - [Data Structures and Algorithms in Python](https://www.wiley.com/en-ua/Data+Structures+and+Algorithms+in+Python-p-9781118549582) - книга з алгоритмів на Python
+  - [Problem Solving with Algorithms and Data Structures using Python](https://runestone.academy/runestone/books/published/pythonds/index.html) - ще одна книга з алгоритмів на Python
   - [Introduction to Algorithms, 3rd Edition (The MIT Press)](https://www.amazon.com/Introduction-Algorithms-3rd-MIT-Press/dp/0262033844)
   - [Mathematics for Computer Science](https://courses.csail.mit.edu/6.042/spring17/mcs.pdf) - book by Eric Lehman
-  - [Структуры данных и алгоритмы в Java](https://www.ozon.ru/context/detail/id/23529814/)
-- Разные полезности
+  - [Data Structures and Algorithms in Java](https://www.amazon.com/Data-Structures-Algorithms-Java-2nd/dp/0672324539)
+- Різні корисності
   - [Algorithms and Data Structures Cheatsheet](https://algs4.cs.princeton.edu/cheatsheet/)
-  - [Algorithms and Complexity questions](https://leetcode.com/discuss/interview-question/469325/google-recruiter-phone-algorithms-and-complexity) неожиданно сплошная теория
+  - [Algorithms and Complexity questions](https://leetcode.com/discuss/interview-question/469325/google-recruiter-phone-algorithms-and-complexity) неочікувано багато теорії
 - Dynamic programming & Backtracking
-  - [Dynamic Programming for Interviews](https://www.byte-by-byte.com/dpbook/)  великолепная книга собирающая в себе Top-Down, Bottom Up approaches. Дающая методологию разбора задачи.
+  - [Dynamic Programming for Interviews](https://www.byte-by-byte.com/dpbook/) чудова книга, що збирає в собі Top-Down, Bottom Up approaches. Дає методологію розбору завдання.
   - [Dynamic Programming for Coding Interviews: A Bottom-Up approach to problem solving](https://www.goodreads.com/book/show/34394300-dynamic-programming-for-coding-interviews) книга
-  - [Динамическое программирование (видео лекции)](https://www.youtube.com/watch?v=AawQnuYSY4Y&list=PLUfHxBkkFMScK6mOOWp5s6LgbzmtfwmYQ) -  курс по динамическому программирования, отлично дает глубокое понимание этого подхода, а также возможность попрактиковаться на решении задач с их разбором
   - [Backtracking introduction](https://www.geeksforgeeks.org/backtracking-introduction/) - geeksforgeeks
-  - [Grokking Dynamic Programming Patterns for Coding Interviews](https://www.educative.io/courses/grokking-dynamic-programming-patterns-for-coding-interviews) - платный курс по динамическом программированию
-  - [Grokking Algorithms](https://www.manning.com/books/grokking-algorithms)  глава объясняющая KnapSack проблем.
-  - [Dynamic Programming lecture #1 - Fibonacci, iteration vs recursion](https://youtu.be/YBSt1jYwVfU) - Errichto дает качественное объяснение приемов Dynamic Programming
+  - [Grokking Dynamic Programming Patterns for Coding Interviews](https://www.educative.io/courses/grokking-dynamic-programming-patterns-for-coding-interviews) - платний курс із динамічного програмування
+  - [Dynamic Programming lecture #1 - Fibonacci, iteration vs recursion](https://youtu.be/YBSt1jYwVfU) - Errichto дає якісне пояснення прийомів Dynamic Programming
   - [Dynamic Programming lecture #2 - Coin change, double counting video](https://youtu.be/1mtvm2ubHCY)
   - [Dynamic Programming Patterns](https://leetcode.com/discuss/general-discussion/458695/dynamic-programming-patterns)  карта задач.
-  - [What Is Dynamic Programming With Python Examples](https://skerritt.blog/dynamic-programming/) - объемная статья на тему динамического программирования с примерами
-- Видео
+  - [What Is Dynamic Programming With Python Examples](https://skerritt.blog/dynamic-programming/) - об'ємна стаття на тему динамічного програмування з прикладами
+  - [Динамічне програмування (відео лекції) (рос.)](https://www.youtube.com/watch?v=AawQnuYSY4Y&list=PLUfHxBkkFMScK6mOOWp5s6LgbzmtfwmYQ) - курс із динамічного програмування, що відмінно дає глибоке розуміння цього підходу, а також можливість попрактикуватися на розв'язанні задач з їх розбором
+- Відео
   - [Introduction to Big O Notation and Time Complexity](https://www.youtube.com/watch?v=D6xkbGLQesk&t=1251s)
-  - [Плейлисты про решение задач на вайтборде](https://youtube.com/user/tusharroy2525/playlis)
-  - [Видео курс по алгоритмам от автора Cracking the coding interview](https://www.youtube.com/playlist?list=PLI1t_8YX-ApvMthLj56t1Rf-Buio5Y8KL)
-  - [Видео курс по структурам данных от автора Cracking the coding interview](https://www.youtube.com/watch?v=IhJGJG-9Dx8&list=PLI1t_8YX-Apv-UiRlnZwqqrRT8D1RhriX)
-  - [Sorting Algorithms (slower, grouped and ordered)](https://www.youtube.com/playlist?list=PLZh3kxyHrVp_AcOanN_jpuQbcMVdXbqei) - анимация 26 сортировок ([нечто похожее](http://sorting.at/))
-  - [Back To Back SWE](https://www.youtube.com/channel/UCmJz2DV1a3yfgrR7GqRtUUA) понравился этот канал. У парня хороший английский, он хорошо объясняет подходы к решению разных задач с описанием процесса решения, появления инсайтов
-  - [WilliamFiset](https://www.youtube.com/channel/UCD8yeTczadqdARzQUp29PJw) - серия видео о теории графов
-  - Списки видео: [базовые алгоритмы](https://www.youtube.com/playlist?list=PLrS21S1jm43geDXVdeQy96P-f59pXeyPC) и  [чуть сложнее базовых](https://www.youtube.com/playlist?list=PLrS21S1jm43iF3DKP3rvpN8hoTBqHVYbr)
-  - [Разбор 75 основных типовых задач на Leetcode](https://youtube.com/channel/UC_mYaQAE6-71rjSN6CeCA-g) - доходчивое изложение на английском.
+  - [Плейлисти про рішення задач на вайтборді](https://youtube.com/user/tusharroy2525/playlis)
+  - [Відеокурс про алгоритми від автора Cracking the coding interview](https://www.youtube.com/playlist?list=PLI1t_8YX-ApvMthLj56t1Rf-Buio5Y8KL)
+  - [Відео курс зі структур даних від автора Cracking the coding interview](https://www.youtube.com/watch?v=IhJGJG-9Dx8&list=PLI1t_8YX-Apv-UiRlnZwqqrRT8D1RhriX)
+  - [Sorting Algorithms (slower, grouped and ordered)](https://www.youtube.com/playlist?list=PLZh3kxyHrVp_AcOanN_jpuQbcMVdXbqei) - анімація 26 алгоритмів сортування ([щось схоже](http://sorting.at/))
+  - [Back To Back SWE](https://www.youtube.com/channel/UCmJz2DV1a3yfgrR7GqRtUUA) сподобався цей канал. У хлопця хороша англійська, він добре пояснює підходи до вирішення різних завдань з описом процесу вирішення, появи йнсайтів
+  - [WilliamFiset](https://www.youtube.com/channel/UCD8yeTczadqdARzQUp29PJw) - серія відео про теорію графів
+  - [Розбір 75 основних типових задач на LeetCode](https://youtube.com/channel/UC_mYaQAE6-71rjSN6CeCA-g) - дохідливе викладення англійською.
+  - Списки відео: [базові алгоритми (рос.)](https://www.youtube.com/playlist?list=PLrS21S1jm43geDXVdeQy96P-f59pXeyPC) и [трохи складніші за базові (рос.)](https://www.youtube.com/playlist?list=PLrS21S1jm43iF3DKP3rvpN8hoTBqHVYbr)
 
 ## Математика
-- Сайты: big-O, элементарные алгоритмы и подходы к ним.
+- Сайти: big-O, елементарні алгоритми та підходи до них.
   - [Wumbo.net](https://wumbo.net/) - Wumbo is a math reference site for students
-- Курсы
-  - [Introduction to Discrete Mathematics for Computer Science](https://www.coursera.org/specializations/discrete-mathematics) - минимальный курс “все в одном” по дискретной математике. Покрывает минимум по важности математического доказательства, комбинаторике, теории вероятностей, теории графов, теории чисел и криптографии. 
-  - [Комбинаторика для начинающих](https://www.coursera.org/learn/kombinatorika-dlya-nachinayushchikh) - хороший вводной курс по комбинаторике. Очень доходчиво и наглядно показаны все основные комбинаторные величины.
-  - [Теория вероятностей для начинающих](https://www.coursera.org/learn/probability-theory-basics) - вводной курс по теории вероятностей.
-  - [Теория графов](https://www.coursera.org/learn/teoriya-grafov) - математический фундамент теории графов. Этот курс более ориентирован на именно “математику” нежели computer science.
-- Книги
-  - [Discrete Mathematics and Its Applications](https://www.amazon.com/Discrete-Mathematics-Its-Applications-Seventh/dp/0073383090) - лучшая книга по дискретной математике по многим критериям.
-  - [Discrete Mathematics with Combinatorics](https://www.amazon.com/Discrete-Mathematics-Combinatorics-James-Anderson/dp/0130869988) - еще одна довольно популярная книга по дискретке.
-  - [Applied Combinatorics](https://www.amazon.com/Applied-Combinatorics-Mitchel-T-Keller/dp/1534878653) - фундаментальный труд по прикладной комбинаторике. Продвинутый уровень.
-  - [Invitation to Number Theory](https://www.amazon.com/Invitation-Number-Theory-Mathematical-Library/dp/0883856530) - очень легкое введение в теорию чисел.
-  - [Number Theory and Its History](https://www.amazon.com/dp/B00A73FH1W/ref=dp-kindle-redirect?_encoding=UTF8&btkr=1) - введение в теорию чисел с хорошим историческим очерком. Подойдет любителям разбавить скучные формулы каплей истории за этими формулами.
-  - [An Introduction to the Theory of Numbers](https://www.amazon.com/Introduction-Theory-Numbers-G-Hardy/dp/0199219869) - хорошая книжка по теории чисел от известного британского математика. Используется как учебное пособие в китайских вышах.
-  - [Elementary Number Theory and Its Application](https://www.amazon.com/Elementary-Number-Theory-Its-Application/dp/0321500318) - фундаментальный труд по теории чисел.
-  - [Introduction to Linear Algebra](https://www.amazon.com/Introduction-Linear-Algebra-Gilbert-Strang/dp/0980232775) - один из полнейших курсов по линейной алгебре.
+- Курси
+  - [Introduction to Discrete Mathematics for Computer Science](https://www.coursera.org/specializations/discrete-mathematics) - мінімальний курс "все в одному" з дискретної математики. Покриває мінімум з важливості математичного доказу, комбінаторики, теорії ймовірностей, теорії графів, теорії чисел і криптографії.
+  - [Discrete Mathematics and Its Applications](https://www.amazon.com/Discrete-Mathematics-Its-Applications-Seventh/dp/0073383090) - найкраща книга з дискретної математики за багатьма критеріями.
+  - [Discrete Mathematics with Combinatorics](https://www.amazon.com/Discrete-Mathematics-Combinatorics-James-Anderson/dp/0130869988) - ще одна доволі популярна книжка із дискретної математики.
+  - [Applied Combinatorics](https://www.amazon.com/Applied-Combinatorics-Mitchel-T-Keller/dp/1534878653) - фундаментальна праця із прикладної комбінаторики. Просунутий рівень.
+  - [Invitation to Number Theory](https://www.amazon.com/Invitation-Number-Theory-Mathematical-Library/dp/0883856530) - дуже легкий вступ до теорії чисел.дуже легкий вступ до теорії чисел.
+  - [Number Theory and Its History](https://www.amazon.com/dp/B00A73FH1W/ref=dp-kindle-redirect?_encoding=UTF8&btkr=1) - уведення в теорію чисел з гарним історичним нарисом. Підійде любителям розбавити нудні формули краплею історії за цими формулами.
+  - [An Introduction to the Theory of Numbers](https://www.amazon.com/Introduction-Theory-Numbers-G-Hardy/dp/0199219869) - гарна книжка з теорії чисел від відомого британського математика. Використовується як навчальний посібник у китайських вишах.
+  - [Elementary Number Theory and Its Application](https://www.amazon.com/Elementary-Number-Theory-Its-Application/dp/0321500318) - фундаментальна праця з теорії чисел.
+  - [Introduction to Linear Algebra](https://www.amazon.com/Introduction-Linear-Algebra-Gilbert-Strang/dp/0980232775) - один із найповніших курсів із лінійної алгебри.
 
-## Олимпиады по программированию
-  - [Как стать Red coder (Grandmaster) on Codeforces](https://drive.google.com/file/d/1TSX395WuwyjzcchvLgSo4vhj_FQflMpi/view)
+## Олімпіади із програмування
+  - [A Way to Practice Competitive Programming](https://drive.google.com/file/d/1TSX395WuwyjzcchvLgSo4vhj_FQflMpi/view)
   - [E-Maxx Algorithms in English](https://cp-algorithms.com/);
-  - [Timus - High quality Online Judge with a lot of solutions on Github](https://acm.timus.ru/);
-  - [Yaal (Yet another algorithm library) by Egor Kulikov](https://github.com/EgorKulikov/yaal) - качественная библиотека на Java для олимпиад. Советую использовать в паре с [Intellij IDEA](https://plugins.jetbrains.com/plugin/7091-chelper) плагином. [Аналогичный плагин для С++ в CLion](https://plugins.jetbrains.com/plugin/7541-jhelper).
+  - [Yaal (Yet another algorithm library) by Egor Kulikov](https://github.com/EgorKulikov/yaal) - якісна бібліотека на Java для олімпіад. Раджу використовувати в парі з [Intellij IDEA](https://plugins.jetbrains.com/plugin/7091-chelper) плагіном. [Аналогічний плагін для С++ в CLion](https://plugins.jetbrains.com/plugin/7541-jhelper).
+  - [Timus - High quality Online Judge with a lot of solutions on GitHub](https://acm.timus.ru/);
 
-## Интересные задачи и списки задач
-- Общие принципы
-  - [Очередность Leetcode задач для новоприбывших.(чтобы меньше страдать)](https://docs.google.com/spreadsheets/d/1je6J87BX5C5fo5Gbok1TJncVK3-UFkiDznHUzhtHbVU/edit#gid=0) и ([объяснение по какому принципу они фильтровались)](https://leetcode.com/discuss/general-discussion/522705/1000-leetcode-problems-within-a-year)
-  - [A LeetCode Grinding Guide - cscareerquestions]() - обсуждение как правильно начинать решать задачи на литкоде.
-  - [14 шаблонов, которые помогут ответить на любой вопрос по коду на 	собеседовании Вопросы на собеседованиях часто](https://tproger.ru/translations/14-templates-to-answer-interview-questions/) (это “переписка” курса Grokking the Coding Interview: Patterns for Coding Questions который уже указан выше)
-- Отдельные задачи
-  - [Palindromic Substrings](https://leetcode.com/problems/palindromic-substrings/description/) - задача с колл в Uber
-  - [Разбор задачи с собеседования в Google: синонимичные запросы](https://m.habr.com/ru/post/437702/)
-  - [Решаем задачу из интервью Google на JavaScript: 4 разных способа](https://m.habr.com/ru/company/skillbox/blog/443886/)
+## Цікаві завдання та списки завдань
+- Загальні принципи
+  - [14 Patterns to Ace Any Coding Interview Question](https://hackernoon.com/14-patterns-to-ace-any-coding-interview-question-c5bb3357f6ed) (це "короткий виклад" курсу Grokking the Coding Interview: Patterns for Coding Questions, що вже вказаний вище)
+- Окремі завдання
+  - [Palindromic Substrings](https://leetcode.com/problems/palindromic-substrings/description/) - завдання з колл у Uber
   - [Google Interview Problems: Ratio Finder](https://medium.com/@alexgolec/google-interview-problems-ratio-finder-d7aa8bf201e3)
-- Подборки задач
-  - [https://www.interviewbit.com/courses/programming/](https://www.interviewbit.com/courses/programming/)  - подборка задач по темам от interviewbit
+  - [Google Interview Questions Deconstructed: Synonymous Queries](https://alexgolec.medium.com/google-interview-problems-synonymous-queries-36425145387c)
+  - [4 Ways to Solve a Google Interview Question in JavaScript](https://bretcameron.medium.com/4-ways-to-solve-a-google-interview-question-in-javascript-12e6eec87576)
+
+- Підбірки завдань
+  - [https://www.interviewbit.com/courses/programming/](https://www.interviewbit.com/courses/programming/)  - підбірка задач за темами від interviewbit
   - [List of Top 75 LeetCode Questions to Save Your Time](https://www.teamblind.com/article/New-Year-Gift---Curated-List-of-Top-100-LeetCode-Questions-to-Save-Your-Time-OaM1orEU) 
-  - [Amazon Online Assessment Questions](https://leetcode.com/discuss/interview-question/344650/Amazon-Online-Assessment-Questions)  из них было Critical Routers, и Product Suggestions
+  - [Amazon Online Assessment Questions](https://leetcode.com/discuss/interview-question/344650/Amazon-Online-Assessment-Questions) з них було Critical Routers, і Product Suggestions
   - [Amazon Final Interview Questions. SDE1](https://leetcode.com/discuss/interview-question/488887/amazon-final-interview-questions-sde1) 
   - [Leetcode questions by likes/dislikes ratio](https://docs.google.com/spreadsheets/d/1LXSO4_Kz_1JMqoZMMuvhpBI99kvsZA4vSSCRAznqnXM/edit?usp=sharing)
   - [Leetcode Patterns](https://seanprashad.com/leetcode-patterns/)
-- Видео
+- Відео
   - [Binary Search with Duplicates video](https://seanprashad.com/leetcode-patterns/)
   - [Mock Google interview (for Software Engineer job) - coding & algorithms tips](https://www.youtube.com/watch?v=IWvbPIYQPFM)
-- Разное
-  - [https://geeksforgeeks.org](https://www.geeksforgeeks.org/) - разбор множества задач и алгоритмов
+- Різне
+  - [https://geeksforgeeks.org](https://www.geeksforgeeks.org/) - розбір безлічі завдань та алгоритмів
   - [Anagram Substring Search (Or Search for all permutations)](https://www.geeksforgeeks.org/anagram-substring-search-search-permutations/)
   - [Construct tree from ancestor matrix](https://www.geeksforgeeks.org/construct-tree-from-ancestor-matrix/)
   - [Top 10 algorithms in Interview Questions](https://www.google.com/amp/s/www.geeksforgeeks.org/top-10-algorithms-in-interview-questions/amp/)
   - [Bit Tricks for Competitive Programming](https://www.geeksforgeeks.org/bit-tricks-competitive-programming/)
 
 ## System Design Interview
-- Все сразу
-  - [Grokking the System Design Interview в 99%](https://www.educative.io/courses/grokking-the-system-design-interview) в первую очередь вам посоветуют пройти курс [(Grokking the System Design Interview - Part 3 )](https://coursehunters.online/t/educative-io-design-gurus-grokking-the-system-design-interview-part-3/581)
-  - [Grokking the Object Oriented Design Interview](https://www.educative.io/courses/grokking-the-object-oriented-design-interview)
-  - [System-design-primer](https://github.com/donnemartin/system-design-primer) Популярный сборник разного по SDI 
-  - [System Design Interview Step By Step Guide](https://www.youtube.com/channel/UC9vLsnF6QPYuH51njmIooCQ/videos). Youtube channel 
-  - [Database Internals: A Deep Dive into How Distributed Data Systems Work](https://www.amazon.com/Database-Internals-Deep-Distributed-Systems/dp/1492040347) - книга говорят бомба типа data intensive
-  - [Building Microservices: Designing Fine-Grained Systems: Newman, Sam: 9781491950357](https://www.amazon.com/Building-Microservices-Designing-Fine-Grained-Systems/dp/1491950358) - очень хорошая книга про разработку микросервисов, легко читается, много хороших практик
-  - [Distributed Systems: Principles and Paradigms: Tanenbaum, Andrew S., van Steen, Maarten: 9780130888938](https://www.amazon.com/Distributed-Systems-Principles-Andrew-Tanenbaum/dp/0130888931) - хорошая популярная книга по распределенным системам, не могу сказать, что читается легко, но стоящая
-  - [https://landing.google.com/sre/books/](https://landing.google.com/sre/books/)  не пугайтесь что про SRE, для SWE можно кой чего пропустить - но есть очень много примеров дизайнов, решений которые были приняты и почему, очень очень хорошее описание что такое load balancing например
-  - [Introduction to modern network load balancing and proxying](https://blog.envoyproxy.io/introduction-to-modern-network-load-balancing-and-proxying-a57f6ff80236) - Еще про load balancer, но это уже чуть подробней чем надо SWE обычно, 
-  - [NoSQL Databases: a Survey and Decision Guidance](https://medium.baqend.com/nosql-databases-a-survey-and-decision-guidance-ea7823a822d#.wskogqenq) - сравнение и описание различных NoSQL систем. Отличие статьи в более практическом анализе - для каких задач, какой тип хранилища подойдет лучше.
+- Усе одразу
+  - [Grokking Modern System Design Interview for Engineers & Managers](https://www.educative.io/courses/grokking-the-system-design-interview) в першу чергу вам порадять пройти курс [(Grokking the System Design Interview - Part 3 )](https://coursehunters.online/t/educative-io-design-gurus-grokking-the-system-design-interview-part-3/581)
+  - [Grokking the Object-Oriented Design Interview](https://www.educative.io/courses/grokking-the-object-oriented-design-interview)
+  - [System-design-primer](https://github.com/donnemartin/system-design-primer) Популярний збірник різного щодо SDI
+  - [System Design Interview Step By Step Guide](https://www.youtube.com/channel/UC9vLsnF6QPYuH51njmIooCQ/videos). YouTube channel 
+  - [Database Internals: A Deep Dive into How Distributed Data Systems Work](https://www.amazon.com/Database-Internals-Deep-Distributed-Systems/dp/1492040347) - книга кажуть "бомба" типу data intensive
+  - [Building Microservices: Designing Fine-Grained Systems: Newman, Sam: 9781491950357](https://www.amazon.com/Building-Microservices-Designing-Fine-Grained-Systems/dp/1491950358) - дуже хороша книга про розробку мікросервісів, легко читається, багато хороших практик
+  - [Distributed Systems: Principles and Paradigms: Tanenbaum, Andrew S., van Steen, Maarten: 9780130888938](https://www.amazon.com/Distributed-Systems-Principles-Andrew-Tanenbaum/dp/0130888931) - хороша популярна книга з розподілених систем, не можу сказати, що читається легко, але варта уваги
+  - [https://landing.google.com/sre/books/](https://landing.google.com/sre/books/)  не лякайтеся, що про SRE, для SWE можна дещо чого пропустити - але є дуже багато прикладів дизайнів, рішень, які було ухвалено й чому, дуже гарний опис що таке load balancing, наприклад
+  - [Introduction to modern network load balancing and proxying](https://blog.envoyproxy.io/introduction-to-modern-network-load-balancing-and-proxying-a57f6ff80236) - Ще про load balancer, але це вже трохи детальніше, ніж треба SWE зазвичай
+  - [NoSQL Databases: a Survey and Decision Guidance](https://medium.baqend.com/nosql-databases-a-survey-and-decision-guidance-ea7823a822d#.wskogqenq) - порівняння та опис різних NoSQL систем. Відмінність статті в більш практичному аналізі - для яких завдань, який тип сховища підійде краще.
   - [System Design Interview Video. Rate Limiting (local and distributed)](https://youtu.be/FU4WlwfS3G0?list=LLVmH0b-Ae4v-ow9l2f5c5bw)
-  - [Prepare for Your Google Interview: Systems Design](https://www.youtube.com/watch?v=Gg318hR5JY0) неожиданно крутое новое видео по system design от Life at Google
-  - [Object-Oriented Design](https://leetcode.com/discuss/interview-question/object-oriented-design?currentPage=1&orderBy=hot&query=) - список вопросов с литкода
-  - Старые статьи с DOU о консенсус-протоколах: [раз](https://dou.ua/lenta/articles/12-konsensus-protocols), [два](https://dou.ua/lenta/articles/konsensus-protocols-2/)
-  - [Raft](http://thesecretlivesofdata.com/raft). Объяснение RAFT на пальцах с красивыми диаграммками. Можете даже показать свой маме!
-  - [Grokking the Mobile System Design interview](https://medium.com/@goncharov.artemv/grokking-the-mobile-system-design-interview-6a06fa94491b?source=friends_link&sk=5d35ee6ade621e3a8018e048d25f6009) - По мотивам систем дизайн собесов в ФБ и Гугл на мобильщика написал статейку. 
-  - [A Simple Framework For Mobile System Design Interviews](https://github.com/weeeBox/mobile-system-design) - структурированный подход к прохождению систем дизайн интервью для iOS/Android разработчиков.
-- Видео
+  - [Prepare for Your Google Interview: Systems Design](https://www.youtube.com/watch?v=Gg318hR5JY0) несподівано круте нове відео з system design від Life at Google
+  - [Object-Oriented Design](https://leetcode.com/discuss/interview-question/object-oriented-design?currentPage=1&orderBy=hot&query=) - список запитань із літкоду
+  - Старі статті з DOU про консенсус-протоколи: [раз](https://dou.ua/lenta/articles/12-konsensus-protocols), [два](https://dou.ua/lenta/articles/konsensus-protocols-2/)
+  - [Raft](http://thesecretlivesofdata.com/raft). Пояснення RAFT на пальцях із красивими діаграмами. Можете навіть показати своїй мамі.
+  - [Grokking the Mobile System Design interview](https://medium.com/@goncharov.artemv/grokking-the-mobile-system-design-interview-6a06fa94491b?source=friends_link&sk=5d35ee6ade621e3a8018e048d25f6009) - За мотивами систем дизайн собесів у ФБ і Гугл на мобільника написав статейку.
+  - [A Simple Framework For Mobile System Design Interviews](https://github.com/weeeBox/mobile-system-design) - структурований підхід до проходження систем дизайн інтерв'ю для iOS/Android розробників.
+- Відео
   - [Software Design Patterns and Principles (quick overview)](https://www.youtube.com/watch?v=WV2Ed1QTst8) 
-  - [Success in Tech](https://www.youtube.com/channel/UC-vYrOAmtrx9sBzJAf3x_xw/featured) - канал о подготовке к интервью, есть видео о дизайне
-  - [System Design Interview](https://www.youtube.com/channel/UC9vLsnF6QPYuH51njmIooCQ) канал по дизайн интервью
-лучше/популярней и понятней лекций по Raft/Paxos я не видел, а глубже наверно только статьи читать: [Raft lecture](https://www.youtube.com/watch?v=YbZ3zDzDnrw), [Paxos lecture](https://www.youtube.com/watch?v=JEpsBg0AO6o)
-  - [System design interview questions](https://www.youtube.com/watch?v=UzLMhqg3_Wc&list=PLrmLmBdmIlps7GJJWW9I7N0P0rB0C3eY2) - плейлист про дизайн интервью с канала [Tushar Roy - Coding Made Simple](https://www.youtube.com/channel/UCZLJf_R2sWyUtXSKiKlyvAw)
+  - [Success in Tech](https://www.youtube.com/channel/UC-vYrOAmtrx9sBzJAf3x_xw/featured) - канал про підготовку до інтерв'ю, є відео про дизайн
+  - [System Design Interview](https://www.youtube.com/channel/UC9vLsnF6QPYuH51njmIooCQ) канал із дизайн-інтерв'ю
+    краще/популярніше і зрозуміліше за лекції з Raft/Paxos я не бачив, а глибше, напевно, тільки статті читати: [Raft lecture](https://www.youtube.com/watch?v=YbZ3zDzDnrw), [Paxos lecture](https://www.youtube.com/watch?v=JEpsBg0AO6o)
+  - [System design interview questions](https://www.youtube.com/watch?v=UzLMhqg3_Wc&list=PLrmLmBdmIlps7GJJWW9I7N0P0rB0C3eY2) - плейлист про дизайн інтерв'ю з каналу [Tushar Roy - Coding Made Simple](https://www.youtube.com/channel/UCZLJf_R2sWyUtXSKiKlyvAw)
   - [https://www.codekarle.com/](https://www.codekarle.com/) 
 - Papers
-  - [Cassandra](https://www.datastax.com/sites/default/files/content/whitepaper/files/2019-09/DataStax-WP-Apache-Cassandra-Architecture.pdf).Можно погуглить разные описания систем. Поисковый запрос вида "BigTable paper" или "MapReduce paper".
-- Воркшопы
-  - [Workshop от Google](https://sre.google/classroom/distributed-pubsub/) по *non-abstract large systems design* на примере *Publish-Subscribe system* 
+  - [Cassandra](https://www.datastax.com/sites/default/files/content/whitepaper/files/2019-09/DataStax-WP-Apache-Cassandra-Architecture.pdf). Можна погуглити різні описи систем. Пошуковий запит типу "BigTable paper" або "MapReduce paper".
+- Воркшопи
+  - [Workshop от Google](https://sre.google/classroom/distributed-pubsub/) по *non-abstract large systems design* на прикладі *Publish-Subscribe system*
 
 
 ## Behavioral interview
-- Видео
-  - видео которое рекомендуют везде: [Episode 07: Intro to Behavioural Interviews](https://www.youtube.com/watch?v=PJKYqLP6MRE)
-  - Тематический канал [Дена Кройтора](https://www.youtube.com/channel/UCw0uQHve23oMWgQcTTpgQsQ/playlists), много инфы и примеров по Amazon LP, FB, Netflix
-- Почитать
-  - [Behavioral Interview. Топики на эту тему на блаинде](https://www.teamblind.com/issue/13246/Behavioral-Interview)
+- Відео
+  - відео, яке рекомендують всюди: [Episode 07: Intro to Behavioural Interviews](https://www.youtube.com/watch?v=PJKYqLP6MRE)
+  - Тематичний канал [Дена Кройтора](https://www.youtube.com/channel/UCw0uQHve23oMWgQcTTpgQsQ/playlists), багато інфи та прикладів щодо Amazon LP, FB, Netflix
+- Почитати
+  - [Behavioral Interview. Топіки на цю тему на blind](https://www.teamblind.com/issue/13246/Behavioral-Interview)
   - Cracking the Coding Interview pages 32-38
   - [The Situation-Behavior-Impact-Feedback Tool - From MindTools.com](https://www.mindtools.com/pages/article/situation-behavior-impact-feedback.htm)
   - [https://leetcode.com/explore/interview/card/leapai/](https://leetcode.com/explore/interview/card/leapai/)
-  - Блог bar-raiser из Amazon об их LP: [Interviewing at Amazon — Leadership Principles - Dave Anderson](https://medium.com/@scarletinked/are-you-the-leader-were-looking-for-interviewing-at-amazon-8301d787815d) 
-  - [Amazon Behavioral questions. Leadership Principles. LP](https://leetcode.com/discuss/interview-question/437082/amazon-behavioral-questions-leadership-principles-lp)  Тут ещё один товарищ из этого чата поучаствовал в эвенте, и у нас у обоих было одинаково: всё вопросы на LP & Behavior были слово в слово из этого списка 
-  - Если это нетфликс или амазон там нужно читать их пейперы по кор вельюсам и быть готовы к вопросам показывающим как ты им соответствуешь.
-  - [Что спрашивают на behavioral и system design интервью, или Как я попал в Facebook](https://dou.ua/lenta/articles/behavioral-system-design-interview-fb/) 
+  - Блог bar-raiser з Amazon про їхній LP: [Interviewing at Amazon — Leadership Principles - Dave Anderson](https://medium.com/@scarletinked/are-you-the-leader-were-looking-for-interviewing-at-amazon-8301d787815d) 
+  - [Amazon Behavioral questions. Leadership Principles. LP](https://leetcode.com/discuss/interview-question/437082/amazon-behavioral-questions-leadership-principles-lp) Тут ще один товариш із цього чату взяв участь в івенті, і в нас в обох було однаково: усі запитання на LP & Behavior були слово в слово із цього списку
+  - Якщо це Netflix або Amazon, там потрібно читати їхні пейпери щодо core values і бути готовими до запитань, які показують, як ти їм відповідаєш.
+  - [Що запитують на behavioral і system design інтерв'ю, або Як я потрапив у Facebook](https://dou.ua/lenta/articles/behavioral-system-design-interview-fb/) 
 
 
-## Переговоры по офферу
+## Переговори щодо оферу
   - [How to Negotiate Your Job Offer - Prof. Deepak Malhotra (Harvard Business School) Video](https://www.youtube.com/watch?v=km2Hd_xgo9Q)
   - [Ten Rules for Negotiating a Job Offer](https://haseebq.com/my-ten-rules-for-negotiating-a-job-offer/)
   - [Patrick McKenzie. Salary Negotiation: Make More Money, Be More Valued](https://www.kalzumeus.com/2012/01/23/salary-negotiation/)
@@ -216,156 +219,151 @@
   - [How I negotiated a $300,000 offer in Silicon Valley](https://medium.com/@bayareabelletrist/how-i-negotiated-a-software-engineer-offer-in-silicon-valley-f11590f5c656) 
   - [Cracking the Tech Career: Insider Advice on Landing a Job at Google, Microsoft, Apple, or any Top Tech Company](https://www.amazon.com/Cracking-Tech-Career-Insider-Microsoft-ebook/dp/B00MFPZ9X6)
 
-## После принятия оффера (в другую страну)
-  - Во избежание конфликтов - не говорите своему работодателю что у вас офер. Скажите когда будет виза. Разница между офером и визой может достигать 12 месяцев.
-  - Сразу поговорите с рекрутером о том, чтобы его кто-то заменил в случае если он внезапно уйдет в отпуск на 2-3 недели - в Европе это любят. Тоже самое с Project manager.
-  - Будет Background check. Сразу подготовьте список всех работодателей и доказательство того, что вы там работали. 
-  - Сразу подготовьте документы в электронном виде. Скан паспорта, загранпаспорта, для Украины (налоговый код, справка о не судимости), диплом. Пожалуйста, допишите для других стран снг
-  - Это все для того, чтобы сэкономить вам от 2 до 4 месяцев. Рекрутеры совсем не торопятся. И могут тянуть из вас документы по одному в неделю. Поэтому приготовьте все сразу. 
+## Після прийняття оферу (до іншої країни)
+  - Щоб уникнути конфліктів - не кажіть своєму роботодавцю, що у вас офер. Скажіть, коли буде віза. Різниця між оффером і візою може сягати 12 місяців.
+  - Одразу поговоріть із рекрутером про те, щоб його хтось замінив, якщо він раптово піде у відпустку на 2-3 тижні - у Європі це люблять. Теж саме з Project manager.
+  - Буде Background check. Одразу підготуйте список усіх роботодавців і доказ того, що ви там працювали.
+  - Одразу підготуйте документи в електронному вигляді. Скан паспорта, закордонного паспорта, податковий код, довідка про несудимість, диплом.
+  - Це все для того, щоб заощадити вам від 2 до 4 місяців. Рекрутери зовсім не поспішають. І можуть тягнути з вас документи по одному на тиждень. Тому приготуйте все одразу.
 
-## Составление резюме
-- От Ларисы
-  - [Пример хорошего резюме](http://larrr.com/primer-horoshego-rezyume/)
-  - [resume Archives](http://larrr.com/category/resume/) - раздел о резюме в блоге Ларисы.
-  - [Resume Checklist или Как Делать Не Надо](http://larrr.com/resume-checklist-ili-kak-delat-ne-nado/)
-  - [Список ключевых слов-достижений](http://larrr.com/hochu-rabotat-v-google-klyuchevye-slova-pri-sostavlenii-rezyume/)
-  - [Список активных глаголов для резюме, разбитый по категориям](https://www.themuse.com/advice/185-powerful-verbs-that-will-make-your-resume-awesome)
-  - [Как отвечать на вопросы на интервью](https://theinterviewguys.com/star-method/)
-- Видео
-  - [Советы от гугл рекрутеров](https://youtu.be/BYUy1yvjHxE)
+## Складання резюме
+- Відео
+  - [Поради від гугл рекрутерів](https://youtu.be/BYUy1yvjHxE)
   - [7 Tips for the Coding Resume (for Software Engineers) video](https://www.youtube.com/watch?v=xpaz7nrNmXA)
-- Шаблоны
+- Шаблони
   - [Result oriented resume templates.](https://github.com/darhonbek/resume_templates)
+- Від Лариси (рос.)
+  - [Пример хорошего резюме (рос.)](http://larrr.com/primer-horoshego-rezyume/)
+  - [resume Archives (рос.)](http://larrr.com/category/resume/) - раздел о резюме в блоге Ларисы.
+  - [Resume Checklist или Как Делать Не Надо (рос.)](http://larrr.com/resume-checklist-ili-kak-delat-ne-nado/)
+  - [Список ключових слів-досягнень (рос.)](http://larrr.com/hochu-rabotat-v-google-klyuchevye-slova-pri-sostavlenii-rezyume/)
+  - [Список активних дієслів для резюме, розбитий за категоріями](https://www.themuse.com/advice/185-powerful-verbs-that-will-make-your-resume-awesome)
+  - [Як відповідати на запитання на інтерв'ю](https://theinterviewguys.com/star-method/)
 
-## Проверка резюме
-По вторникам и субботам в [/r/cscareequestions](https://www.reddit.com/r/cscareerquestions/) создаются “Resume Advice” тредs, где можно получить фидбек.
-Телеграм канал для обсуждения резюме: [resume_review](https://t.me/resume_review)
-[Rooftop Slushie - платно](https://www.rooftopslushie.com/resume_review)
+
+## Перевірка резюме
+По вівторках і суботах у [/r/cscareequestions](https://www.reddit.com/r/cscareerquestions/) створюються "Resume Advice" треди, де можна отримати фідбек.
+Телеграм-канал для обговорення резюме: [resume_review (рос.)](https://t.me/resume_review)
 
 ## SRE
-- Разное
-  - [Linux Technical Interview Questions and Answers  (Linux)](https://www.udemy.com/course/linux-technical-interview-questions-and-answers/) - платный курс
-  - [My Job Interview at Google](https://catonmat.net/my-job-interview-at-google)  Google SRE interview on SRE
+- Різне
+  - [Linux Technical Interview Questions and Answers  (Linux)](https://www.udemy.com/course/linux-technical-interview-questions-and-answers/) - платний курс
+  - [My Job Interview at Google](https://catonmat.net/my-job-interview-at-google) Google SRE interview on SRE
   - [What happens when we hit URL in Browser?](https://www.freecodecamp.org/news/what-happens-when-you-hit-url-in-your-browser/) 
   - [SYSADMIN. The Systems Engineering Side of Site Reliability Engineering](https://www.usenix.org/system/files/login/articles/login_june_08_hixson.pdf)
   - [SYSADMIN. Hiring Site Reliability Engineers](https://www.usenix.org/system/files/login/articles/login_june_07_jones.pdf)
   - [https://github.com/mxssl/sre-interview-prep-guide](https://github.com/mxssl/sre-interview-prep-guide)
-- Почитать
-  - [Site Reliability Engineering](https://landing.google.com/sre/books/) книга
+- Почитати
+  - [Site Reliability Engineering](https://landing.google.com/sre/books/)
   - [Linux System Programming: Talking Directly To The Kernel And C Library](https://www.amazon.com/Linux-System-Programming-Talking-Directly/dp/1449339530/ref=sr_1_12?crid=2BXSSOER0QTDS&keywords=linux+programming&qid=1579717475&sprefix=linux%2Caps%2C234&sr=8-12) 
-  - [Systems Performance: Enterprise and the Cloud](https://www.amazon.com/Systems-Performance-Enterprise-Brendan-Gregg/dp/0133390098/ref=sr_1_2?crid=29XENXAQ8F4U6&keywords=brendan+gregg&qid=1579717501&sprefix=brandan+gre%2Caps%2C243&sr=8-2), сайт автора [http://www.brendangregg.com](http://www.brendangregg.comhttp://www.brendangregg.com) 
-  - [BPF Performance Tools (Addison-Wesley Professional Computing Series)](https://www.amazon.com/Performance-Tools-Addison-Wesley-Professional-Computing/dp/0136554822/ref=sr_1_1?crid=29XENXAQ8F4U6&keywords=brendan+gregg&qid=1579717501&sprefix=brandan+gre%2Caps%2C243&sr=8-1) снова  [http://www.brendangregg.com](http://www.brendangregg.com)  
+  - [Systems Performance: Enterprise and the Cloud](https://www.amazon.com/Systems-Performance-Enterprise-Brendan-Gregg/dp/0133390098/ref=sr_1_2?crid=29XENXAQ8F4U6&keywords=brendan+gregg&qid=1579717501&sprefix=brandan+gre%2Caps%2C243&sr=8-2), сайт автора [http://www.brendangregg.com](http://www.brendangregg.com) 
+  - [BPF Performance Tools (Addison-Wesley Professional Computing Series)](https://www.amazon.com/Performance-Tools-Addison-Wesley-Professional-Computing/dp/0136554822/ref=sr_1_1?crid=29XENXAQ8F4U6&keywords=brendan+gregg&qid=1579717501&sprefix=brandan+gre%2Caps%2C243&sr=8-1) знову  [http://www.brendangregg.com](http://www.brendangregg.com)  
   - [Operating Systems: Three Easy Pieces](http://pages.cs.wisc.edu/~remzi/OSTEP/)
   - [The Linux Programming Interface: A Linux and UNIX System Programming Handbook](https://www.amazon.com/Linux-Programming-Interface-System-Handbook/dp/1593272200/ref=sr_1_1?crid=2BXSSOER0QTDS&keywords=linux+programming&qid=1579717475&sprefix=linux%2Caps%2C234&sr=8-1)
-  - [Grokking the Mobile System Design interview ](https://medium.com/@goncharov.artemv/grokking-the-mobile-system-design-interview-6a06fa94491b?source=friends_link&sk=5d35ee6ade621e3a8018e048d25f6009)- По мотивам систем дизайн собесов в ФБ и Гугл на мобильщика написал статейку.
+  - [Grokking the Mobile System Design interview ](https://medium.com/@goncharov.artemv/grokking-the-mobile-system-design-interview-6a06fa94491b?source=friends_link&sk=5d35ee6ade621e3a8018e048d25f6009)- За мотивами систем дизайн собесів у ФБ і Гугл на мобільника написав статейку.
   - [Yet another mobile architectures comparison](https://medium.com/@goncharov.artemv/yet-another-mobile-architectures-comparison-73f4eb39b4a0)
   - [Mobile architecture optimization topics](https://www.teamblind.com/post/mobile-architecture-mega-list-BXb8Ohvn).
   - [The System Design Interview For Mobile Developers](https://davescommutebloghome.wpcomstaging.com/author/normand1/page/2/).
-  - [Что спрашивают на behavioral и system design интервью, или Как я попал в Facebook](https://dou.ua/lenta/articles/behavioral-system-design-interview-fb/).
+  - [Що запитують на behavioral і system design інтерв'ю, або Як я потрапив у Facebook](https://dou.ua/lenta/articles/behavioral-system-design-interview-fb/).
   - [Pagination](https://slack.engineering/evolving-api-pagination-at-slack/).
-  - [A Simple Framework For Mobile System Design Interviews](https://github.com/weeeBox/mobile-system-design) - структурированный подход к прохождению систем дизайн интервью для iOS/Android разработчиков.
+  - [A Simple Framework For Mobile System Design Interviews](https://github.com/weeeBox/mobile-system-design) - структурований підхід до проходження систем дизайн інтерв'ю для iOS/Android розробників.
 
 ## Frontend
-- Разное
-  - [https://blog.pramp.com/how-to-succeed-in-a-frontend-interview-d748cb073823?gi=1d9930d41bfb](https://blog.pramp.com/how-to-succeed-in-a-frontend-interview-d748cb073823?gi=1d9930d41bfb) - Описание общего объема желательных знаний на позицию Frontend-инженера со ссылками где почитать. Ссылки из статьи на доп. Ресурсы:
+- Різне
+  - [https://blog.pramp.com/how-to-succeed-in-a-frontend-interview-d748cb073823?gi=1d9930d41bfb](https://blog.pramp.com/how-to-succeed-in-a-frontend-interview-d748cb073823?gi=1d9930d41bfb) - Опис загального обсягу бажаних знань на позицію Frontend-інженера з посиланнями, де почитати. Посилання зі статті на дод. ресурси:
   - [Frontend Job Interview Questions](https://github.com/h5bp/Front-end-Developer-Interview-Questions)  — The largest Github repository of frontend interview questions
   - [Cracking the Frontend Interview](https://medium.freecodecamp.org/cracking-the-front-end-interview-9a34cd46237)  — A guide by Jonathan White, a Twitter engineer, on how to prepare for frontend interviews
   - [Frontend Developer Handbook 2018](https://frontendmasters.com/books/front-end-handbook/2018/)  — A guide on Frontend Development and interview preparation created by Frontend Masters
   - [Cracking the Frontend Coding Interview](https://blog.usejournal.com/cracking-the-frontend-coding-interview-ec7d5b1e6755)  — An article by Alex Pattison, an engineer at Yola, on questions and answers for frontend interviews
-  - [https://www.pramp.com/](https://www.pramp.com/) - Тут есть возможность практиковаться в интервью по тематике Frontend
-  - [http://gainlo.co](http://gainlo.co)  - Платный ресурс для Mock-интервью в том числе по Frontend System Design. Дают развернутый фидбек.
-  - [Большой док по фронтенд подготовке в FAANG](https://www.notion.so/evgeniiray/Front-End-Preparation-a0ac842415a04ddf9319718ea6ba22a4) 
+  - [https://www.pramp.com/](https://www.pramp.com/) - Тут є можливість практикуватися в інтерв'ю за тематикою Frontend
+  - [http://gainlo.co](http://gainlo.co)  - Платний ресурс для Mock-інтерв'ю, зокрема з Frontend System Design. Дають розгорнутий фідбек.
+  - [Large Front-End Preparation for FAANG Notion guide](https://www.notion.so/evgeniiray/Front-End-Preparation-a0ac842415a04ddf9319718ea6ba22a4) 
   - [System Design for Front End Engineers](https://www.youtube.com/channel/UC6YpkaZsAcAvPNt4rLiS7dg) 
-  - [Leetcode-like портал, сфокусированный на фронтенде](https://bigfrontend.dev/) 
+  - [Leetcode-like портал, сфокусований на фронтенді](https://bigfrontend.dev/) 
 
-## Интернатура
+## Інтернатура
   - [Summer 2020 Internships](https://github.com/elaine-zheng/summer2020internships) 
-  - [Статьи о стажировке в фаанг](https://dou.ua/lenta/tags/путь%20стажера/) 
-  - [Стажировки в международных компаниях: как не завалить интервью и получить заветный оффер](https://habr.com/ru/company/hsespb/blog/472644/) 
-  - [Как попасть на 5 стажировок в ФААНГ](https://youtu.be/YhuZ7lb8rGE) 
+  - [Статті про стажування у фаанг](https://dou.ua/lenta/tags/путь%20стажера/) 
+  - [Стажування в міжнародних компаніях: як не завалити інтерв'ю та отримати заповітний оффер (рос.)](https://archive.ph/E0N0e) 
+  - [Як потрапити на 5 стажувань у ФААНГ (рос.)](https://youtu.be/YhuZ7lb8rGE) 
 
-## Релокация
-  - [Релокация в Сингапур: история украинского архитектора](https://dou.ua/lenta/articles/relocation-to-singapore/) . Хорошая статья о жизни в Сингапуре, финансах и т.д.
-  - [Как попасть в Кремниевую Долину. Video](https://youtu.be/bsrW1qQGKcQ)  
-  - [https://t.me/FbCovid](https://t.me/FbCovid)  - мини группа для обсуждения переезда в ФБ Лондон в текущей ситуации с вирусом. Для тех, кто сейчас находится в процессе обсуждения офера или уже подписал его, но еще не переехал из-за вируса
-  - [https://t.me/canada_it](https://t.me/canada_it)  - чатик айтишников по канаде + полезные чаты по Канаде [https://canadakaknado.info/#chats](https://canadakaknado.info/#chats) 
-  - [https://relhut.com/visa-sponsors](https://relhut.com/visa-sponsors)  - список спонсоров Tier 2 визы, не только FAANG
-  - [https://relhut.com/salary-calculator](https://relhut.com/salary-calculator)   - калькурятор базовой зарплаты в ЮК для технических позиций
+## Релокація
+  - [Релокація в Сінгапур: історія українського архітектора](https://dou.ua/lenta/articles/relocation-to-singapore/). Хороша стаття про життя в Сінгапурі, фінанси тощо.
+  - [https://relhut.com/visa-sponsors](https://relhut.com/visa-sponsors)  - список спонсорів Tier 2 візи, не тільки FAANG
+- [https://relhut.com/salary-calculator](https://relhut.com/salary-calculator)   - калькурятор базової зарплати в ЮК для технічних позицій
+  - [Як потрапити в Кремнієву Долину (рос.)](https://youtu.be/bsrW1qQGKcQ)
+  - [https://t.me/canada_it (рос.)](https://t.me/canada_it)  - чатик айтішників по Канаді + корисні чати по Канаді [https://canadakaknado.info/#chats (рос.)](https://canadakaknado.info/#chats) 
 
 ## Разное
-- Истории из жизни:
-  - [Why I studied full-time for 8 months for a Google interview](https://www.freecodecamp.org/news/why-i-studied-full-time-for-8-months-for-a-google-interview-cc662ce9bb13/)  - Статья про подготовку в Google за 8 месяцев() + [русская версия](https://proglib.io/p/8-month-for-google-interview/)  
-  - [Про то, как я попал на интервью в Microsoft Ireland](https://medium.com/@ykurmangaliyev/%D0%BF%D1%80%D0%BE-%D1%82%D0%BE-%D0%BA%D0%B0%D0%BA-%D1%8F-%D0%BF%D0%BE%D0%BF%D0%B0%D0%BB-%D0%BD%D0%B0-%D0%B8%D0%BD%D1%82%D0%B5%D1%80%D0%B2%D1%8C%D1%8E-%D0%B2-microsoft-ireland-86a3101b335a) 
-  - [Подготовка к собеседованию в Microsoft: polycode](https://polycode.livejournal.com/29426.html) 
-  - [Как подготовиться к собеседованию в Google и не пройти его. Дважды](https://habr.com/ru/post/419945/) 
+- Історії з життя:
+  - [Why I studied full-time for 8 months for a Google interview](https://www.freecodecamp.org/news/why-i-studied-full-time-for-8-months-for-a-google-interview-cc662ce9bb13/) - Стаття про підготовку в Google за 8 місяців
+  - [Про те, як я потрапив на інтерв'ю в Microsoft Ireland (рос.)](https://medium.com/@ykurmangaliyev/%D0%BF%D1%80%D0%BE-%D1%82%D0%BE-%D0%BA%D0%B0%D0%BA-%D1%8F-%D0%BF%D0%BE%D0%BF%D0%B0%D0%BB-%D0%BD%D0%B0-%D0%B8%D0%BD%D1%82%D0%B5%D1%80%D0%B2%D1%8C%D1%8E-%D0%B2-microsoft-ireland-86a3101b335a) 
+  - [Підготовка до співбесіди в Microsoft: polycode (рос.)](https://polycode.livejournal.com/29426.html) 
+  - [Як підготуватися до співбесіди в Google і не пройти її. Двічі (рос.)](https://archive.ph/FRNOX) 
 - Солянка
-  - [Комбинаторика: основные правила и формулы](https://ya-znau.ru/znaniya/zn/80) .
-  - [Видео на Khan Academy по комбинаторике](https://www.khanacademy.org/math/precalculus/x9e81a4f98389efdf:prob-comb/x9e81a4f98389efdf:combinatorics-precalc/v/factorial-and-counting-seat-arrangements)   (и потом [второй блок](https://www.khanacademy.org/math/statistics-probability/counting-permutations-and-combinations), там же) - учит выводить комбинаторные формулы (permutations, combinations) на ходу, прикидыванием, а не запоминать их.
-  - [Вся правда о собеседованиях в Google: за пределами NDA](http://blogerator.org/page/google) 
-  - [Amazon Banned Questions](https://docs.google.com/spreadsheets/d/1bJRbxssWmP5C8iv5MQvOkh4k2LeCgLsjbaosrIBVPf0/edit#gid=0) 
+  - [Відео на Khan Academy з комбінаторики](https://www.khanacademy.org/math/precalculus/x9e81a4f98389efdf:prob-comb/x9e81a4f98389efdf:combinatorics-precalc/v/factorial-and-counting-seat-arrangements) (і потім [другий блок](https://www.khanacademy.org/math/statistics-probability/counting-permutations-and-combinations), там же) - вчить виводити комбінаторні формули (permutations, combinations) на ходу, прикиданням, а не запам'ятовувати їх.
   - [Amazon 1st round Interview questions (manager level)](https://www.reddit.com/r/ITCareerQuestions/comments/cz9ctv/amazon_1st_round_interview_questions_manager_level/?utm_medium=android_app&utm_source=share)  
   - [Levels.fyi: Compare salaries and career levels across companies](https://www.levels.fyi/)  
+  - [Комбінаторика: основні правила та формули (рос.)](https://archive.ph/tYJKA).
 - Книги
-  - [Introduction to Information Retrieval](https://nlp.stanford.edu/IR-book/pdf/irbookonlinereading.pdf) (на русском [Вильямс книга Введение в информационный поиск)](http://www.williamspublishing.com/Books/978-5-8459-1623-5.html) 
-Сайты для изучения программирования
-  - [Interview Practice](https://app.codesignal.com/interview-practice)   - средние между leetcode и codewars 
-  - [https://www.codewars.com](https://www.codewars.com)  - для изучения языков, обилие задач и технических приемов
+  - [Introduction to Information Retrieval](https://nlp.stanford.edu/IR-book/pdf/irbookonlinereading.pdf)
+Сайти для вивчення програмування
+  - [Interview Practice](https://app.codesignal.com/interview-practice) - середні між LeetCode і CodeWars
+  - [https://www.codewars.com](https://www.codewars.com) - для вивчення мов, велика кількість завдань і технічних приймань
   - [Firecode.io, Coding Interview Answers and Trainer](https://www.firecode.io/)  
-- Список ресурсов, на которых можно найти рефералов (из какой-то статьи):
+- Список ресурсів, на яких можна знайти рефералів (з якоїсь статті):
   - [https://repher.me/](https://repher.me/) 
   - [https://www.teamblind.com](https://www.teamblind.com) 
-  - [https://www.rooftopslushie.com/](https://www.rooftopslushie.com/)   - за деньги
+  - [https://www.rooftopslushie.com/](https://www.rooftopslushie.com/) - за гроші
   - [https://triplebyte.com/](https://triplebyte.com/)  
-- Списки компаний по регионам
+- Списки компаній за регіонами
   - [BigN-style Interview Europe](https://docs.google.com/spreadsheets/d/1jJehhHdt1dHHnCtbWqLjc4o-GKBdlDixgma7oJXlBMQ/edit#gid=0)  
   - [Europe companies](https://docs.google.com/spreadsheets/d/1HTmdCYbdF22n3irlvvdfmfAY7WZDR_-pwlO8FJrYHlY/edit#gid=0) 
 
-## Английский
-- Сайты для общения с рандомными людьми голос/текст/видео
-  - [speaking24.com](http://speaking24.com/)   - если хочется пообщаться, можно вписать свой скайп или позвонить тем кто онлайн
-  - [talkwithstranger.com](https://talkwithstranger.com/)   - бесплатный чат на английском, много комнат разбитых на разные темы
-  - [tohla.com](http://www.tohla.com/)   - бесплатный чат (текст/голос/видео)
-  - [omegle.com](https://www.omegle.com/)   - бесплатный чат (текст/видео)
-  - [free4talk.com](https://www.free4talk.com/)   - бесплатные видеочаты на разных языках, hangouts/и на самом сайте, группы по 2-10 человек
-  - [strangermeetup.com](https://strangermeetup.com/)  - Stranger Meetup
-  - [verbling.com](https://www.verbling.com/)   - здесь когда то были бесплатные видеосозвоны в hangouts
-  - [italki.com](https://www.italki.com/)   - платные преподаватели (от $3 в час) комьюнить бесплатно проверяет тексты, эссе, можно заводить друзей
-- Разные соцсети для языкового обмена
-  - [paltalk.com](https://www.paltalk.com/) 
-  - [lang-8](https://lang-8.com/) 
-  - [searchy.net](https://ppi.searchy.net/) 
-  - [interpals.net](https://www.interpals.net/) 
-  - [epals.com](https://www.epals.com/) 
-  - [easylanguageexchange.com](https://www.easylanguageexchange.com/)  - Easy Language Exchange
-  - [conversationexchange.com](https://www.conversationexchange.com/)   - Conversation Exchange
-  - [languageforexchange.com](https://www.languageforexchange.com/)  - Language for exchange
-  - [englishbaby.com](https://www.englishbaby.com/) 
-- Бесплатные тесты времена/грамматика/итд
-  - [englisch-hilfen.de](https://www.englisch-hilfen.de/en/) 
-  - [ego4u.com](https://www.ego4u.com/en/) 
-  - [esl-lounge.com](https://www.esl-lounge.com/) 
-  - [manythings.org](http://www.manythings.org/) 
-  - [correctenglish.ru](http://www.correctenglish.ru/tests/) 
-  - [examenglish.com](https://www.examenglish.com/)  - TOEFL reading test
-  - [lengish.com](https://lengish.com/tests/) 
-- Сайты для изучения языка в игровой форме
-  - [duolingo.com](https://www.duolingo.com/) 
-  - [lingualeo.com](https://lingualeo.com/ru/) 
-  - [puzzle-english.com](https://en.puzzle-english.com/) 
-- Аудио книги
-  - [loyalbooks.com](http://www.loyalbooks.com/)   - Audiobooks eBooks
-  - [Za4itaika.ru](https://za4itaika.ru/Pages/)   - Free Public Domain Audiobooks
-- Видео, тесты
-  - [voanews.com](https://learningenglish.voanews.com/)   - Voice of America Learning English
-  - [bbc.co.uk](http://www.bbc.co.uk/learningenglish/english/course/eiam/unit-1/session-70)  - BBC Learning English
-  - [perfect-english-grammar.com](https://www.perfect-english-grammar.com/present-simple.html) 
-  - [ted.com](https://www.ted.com/talks)  - TED Talks
-- Переводчики, полезные штуки
-  - [englishconversationquestions.com](https://englishconversationquestions.com/)   - рандомные вопросы для общения с людьми
-  - [forvo.com](https://ru.forvo.com/)   - база произношений
-  - [cambridge.org](https://dictionary.cambridge.org/dictionary/english/)   - Cambridge Dictionary
-  - [multitran.com](https://www.multitran.com/)   - переводчик multitran
-  - [grammarly](https://grammarly.com/)  - проверка грамматики
-  - [https://context.reverso.net/translation/](https://context.reverso.net/translation/)   - перевод по контексту, во многих случаях намного полезней гугла переводчика
-  - [https://fluent.express](https://fluent.express)  -  проверка текста реальными людьми (профессиональными едиторами), платное но к примеру для проверки резюме может пригодится
-  - [https://playphrase.me/](https://playphrase.me/)  - пишешь фразу, сервис показывает отрывки фильмов  с произношением этой фразы.
+## Англійська мова
+- Сайти для спілкування з рандомними людьми голос/текст/відео
+  - [speaking24.com](http://speaking24.com/) - якщо хочеться поспілкуватися, можна вписати свій скайп або зателефонувати тим, хто онлайн
+  - [talkwithstranger.com](https://talkwithstranger.com/) - безплатний чат англійською, багато кімнат, розбитих на різні теми
+- [tohla.com](http://www.tohla.com/) - безплатний чат (текст/голос/відео)
+  - [omegle.com](https://www.omegle.com/) - безплатний чат (текст/відео)
+  - [free4talk.com](https://www.free4talk.com/) - безплатні відеочати різними мовами, hangouts/і на самому сайті, групи по 2-10 осіб
+  - [strangermeetup.com](https://strangermeetup.com/) - Stranger Meetup
+  - [verbling.com](https://www.verbling.com/) - тут колись були безплатні відеодзвінки в hangouts
+  - [italki.com](https://www.italki.com/) - платні викладачі (від $3 на годину) ком'юніті безплатно перевіряє тексти, есе, можна заводити друзів
+- Різні соцмережі для мовного обміну
+  - [paltalk.com](https://www.paltalk.com/)
+  - [lang-8](https://lang-8.com/)
+  - [searchy.net](https://ppi.searchy.net/)
+  - [interpals.net](https://www.interpals.net/)
+  - [epals.com](https://www.epals.com/)
+  - [easylanguageexchange.com](https://www.easylanguageexchange.com/) - Easy Language Exchange
+  - [conversationexchange.com](https://www.conversationexchange.com/) - Обмін розмовами
+  - [languageforexchange.com](https://www.languageforexchange.com/) - Мова для обміну
+  - [englishbaby.com](https://www.englishbaby.com/)
+- Безплатні тести часи/граматика/ітд
+  - [englisch-hilfen.de](https://www.englisch-hilfen.de/en/)
+  - [ego4u.com](https://www.ego4u.com/en/)
+  - [esl-lounge.com](https://www.esl-lounge.com/)
+  - [manythings.org](http://www.manythings.org/)
+  - [examenglish.com](https://www.examenglish.com/) - тест на читання TOEFL
+  - [lengish.com (рос.)](https://lengish.com/tests/)
+- Сайти для вивчення мови в ігровій формі
+  - [duolingo.com](https://www.duolingo.com/)
+  - [lingualeo.com](https://lingualeo.com/uk)
+  - [puzzle-english.com](https://en.puzzle-english.com/)
+- Аудіо книги
+  - [loyalbooks.com](http://www.loyalbooks.com/) - Audiobooks eBooks
+- Відео, тести
+  - [voanews.com](https://learningenglish.voanews.com/) - Voice of America Learning English
+  - [bbc.co.uk](http://www.bbc.co.uk/learningenglish/english/course/eiam/unit-1/session-70) - BBC Learning English
+  - [perfect-english-grammar.com](https://www.perfect-english-grammar.com/present-simple.html)
+  - [ted.com](https://www.ted.com/talks) - TED Talks
+- Перекладачі, корисні штуки
+  - [englishconversationquestions.com](https://englishconversationquestions.com/) - рандомні запитання для спілкування з людьми
+  - [forvo.com](https://forvo.com) - база вимов
+  - [cambridge.org](https://dictionary.cambridge.org/dictionary/english/) - Cambridge Dictionary
+  - [multitran.com](https://www.multitran.com/) - перекладач multitran
+  - [grammarly](https://grammarly.com/) - перевірка граматики
+  - [https://context.reverso.net/translation/](https://context.reverso.net/translation/) - переклад за контекстом, у багатьох випадках набагато корисніший за гугл перекладача
+  - [https://fluent.express](https://fluent.express) - перевірка тексту реальними людьми (професійними редакторами), платне, але, приміром, для перевірки резюме може стати в пригоді
+  - [https://playphrase.me/](https://playphrase.me/) - пишеш фразу, сервіс показує уривки фільмів із вимовою цієї фрази.


### PR DESCRIPTION
- translated
- all sources in russian (it turned out there are not so many of them)
  - are moved down
  - non-working resources removed
  - marked with `(рос)` like it's done on Wikipedia 
  - DOU.ua articles in russian do not have this mark, and this should be done on DOU.ua  side sometime in the future, I believe
- some links that were translations to russian were replaced with the original articles
- habr.com/ru is replaced with archive.ph to make sure habr does not earn from visitors viewing ads

#TODO for the future: translated two Google docs about mocks